### PR TITLE
Improve the handling of `---` in code blocks

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -826,7 +826,7 @@ class HorizontalBlockRenderer extends MarkdownRenderChild {
     const savedLayout =
       this.plugin.settings[`horizontal-block-layout-${blockId}`] || {};
 
-    const sections = this.source.split(/^---$/m).map((part) => part.trim());
+    const sections = this.splitSections(this.source);
     const blocks: HTMLElement[] = [];
 
     for (let index = 0; index < sections.length; index++) {
@@ -875,6 +875,46 @@ class HorizontalBlockRenderer extends MarkdownRenderChild {
     for (let i = 0; i < blocks.length; i++) {
       this.attachToolbar(container, blocks, blockId, i);
     }
+  }
+
+  private splitSections(source: string): string[] {
+    const lines = source.split(/\r?\n/);
+    const sections: string[] = [];
+    const codeBlockRegex = /^\s*(`{3,}|~{3,})(.*)$/;
+
+    let currentSection: string[] = [];
+    let codeBlockMarker: { marker: string; length: number } | null = null;
+
+    for (const line of lines) {
+      const fenceMatch = line.match(codeBlockRegex);
+
+      if (!codeBlockMarker && fenceMatch) {
+        codeBlockMarker = {
+          marker: fenceMatch[1][0],
+          length: fenceMatch[1].length,
+        };
+      } else if (
+        codeBlockMarker &&
+        fenceMatch &&
+        fenceMatch[1][0] === codeBlockMarker.marker &&
+        fenceMatch[1].length >= codeBlockMarker.length
+      ) {
+        codeBlockMarker = null;
+      }
+
+      if (!codeBlockMarker && line.trim() === "---") {
+        sections.push(currentSection.join("\n").trim());
+        currentSection = [];
+        continue;
+      }
+
+      currentSection.push(line);
+    }
+
+    sections.push(currentSection.join("\n").trim());
+    currentSection = [];
+
+    return sections;
   }
 
   async createRenderedBlock(


### PR DESCRIPTION
Hello, thank you for creating such a wonderful plugin.
It is helps me to compare before and after version of a change together :)

Currently, this plugin detects column boundaries using a simple method: split(/ ^---$/m).
However, this method also reacts to --- within code blocks, making it impossible to achieve certain layouts.

This PR focus to improve `---` within code blocks.

| sample input | ASIS | TOBE |
| --- | --- | --- |
| [sample.md](https://github.com/user-attachments/files/23338327/sample.md) | <img height="150" src="https://github.com/user-attachments/assets/f84937ea-7a52-47a0-8bd9-210aac6c82c6" /> |  <img height="150" src="https://github.com/user-attachments/assets/2cae51b5-5645-4e8f-9d5d-76b07f12d8ef" /> |
| [sample2.md](https://github.com/user-attachments/files/23338330/sample2.md) | <img height="150"  src="https://github.com/user-attachments/assets/1421d5e3-ccb9-4cbd-8824-5e6537b380dd" /> | <img height="150" src="https://github.com/user-attachments/assets/098443d1-ffaa-414e-9fee-d0625f432025" /> |
| [sample3.md](https://github.com/user-attachments/files/23338386/sample3.md) | <img height="150"  src="https://github.com/user-attachments/assets/e151434c-3d15-41d3-8eb0-3e47e53d1b04" /> | <img height="150" src="https://github.com/user-attachments/assets/e78db0ce-9a54-4656-8e48-aa6d91d15145" /> |

I'd be happy to help you.